### PR TITLE
Fix: Update API calls to use local endpoint and add proxy configuration

### DIFF
--- a/api/random.js
+++ b/api/random.js
@@ -1,0 +1,12 @@
+export default async function handler(req, res) {
+  try {
+    const response = await fetch("https://api.quotable.io/random");
+    if (!response.ok) {
+      throw new Error("API request failed");
+    }
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (error) {
+    res.status(500).json({ error: "Failed to fetch quote" });
+  }
+}

--- a/src/components/Quotes.jsx
+++ b/src/components/Quotes.jsx
@@ -2,14 +2,14 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 
 const Quotes = () => {
-  const [quote, setQuote] = useState([]);
-  const [author, setAuthor] = useState([]);
+  const [quote, setQuote] = useState("");
+  const [author, setAuthor] = useState("");
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setLoading(true);
     axios
-      .get("https://api.quotable.io/random")
+      .get("/api/random")
       .then((res) => {
         setQuote(res.data.content);
         setAuthor(res.data.author);
@@ -24,11 +24,10 @@ const Quotes = () => {
   const onChangeFetch = async () => {
     setLoading(true);
     try {
-      await axios.get("https://api.quotable.io/random").then((res) => {
-        setQuote(res.data.content);
-        setAuthor(res.data.author);
-        setLoading(false);
-      });
+      const res = await axios.get("/api/random");
+      setQuote(res.data.content);
+      setAuthor(res.data.author);
+      setLoading(false);
     } catch (error) {
       console.log(error);
       setLoading(false);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,18 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "https://api.quotable.io",
+        changeOrigin: true,
+
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
This pull request refactors how the app fetches random quotes by introducing a backend API route and updating the frontend to use it. This change improves security and flexibility by proxying requests through the local server instead of calling the external API directly from the client. The most important changes are grouped below.

**Backend API Implementation:**

* Added a new API route `api/random.js` that fetches a random quote from `quotable.io` and returns the result, handling errors gracefully.

**Frontend Refactoring:**

* Updated `Quotes.jsx` to fetch quotes from the new `/api/random` endpoint instead of directly from the external API, both on initial load and when fetching a new quote. [[1]](diffhunk://#diff-4b8526c4cb3c4df36842e9c1d8cdc4e7a9c1db3a803fd9ad020348f699714c5fL5-R12) [[2]](diffhunk://#diff-4b8526c4cb3c4df36842e9c1d8cdc4e7a9c1db3a803fd9ad020348f699714c5fL27-L31)
* Changed the state initialization for `quote` and `author` from arrays to strings for proper data handling.

**Development Server Configuration:**

* Configured Vite's dev server to proxy `/api` requests to `quotable.io`, rewriting the path and enabling CORS and local development without exposing API keys.